### PR TITLE
Fix silent login failures in resin-ui

### DIFF
--- a/packages/resin-event-log/CHANGELOG.md
+++ b/packages/resin-event-log/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Make GA more resilient to incorrect usage and tracking problems
+
 ## 1.1.0
 
 * Now running $set (instead of $set_once) for the user props we'd like to keep up to date

--- a/packages/resin-event-log/CHANGELOG.md
+++ b/packages/resin-event-log/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.1.1
+
 * Make GA more resilient to incorrect usage and tracking problems
 
 ## 1.1.0

--- a/packages/resin-event-log/src/resin-event-log.js
+++ b/packages/resin-event-log/src/resin-event-log.js
@@ -70,6 +70,9 @@ module.exports = function(options) {
 			return runForAllAdaptors('login', [ user ], callback)
 		},
 		end: function(callback) {
+			if (!this.userId) {
+				return Promise.resolve()
+			}
 			this.userId = null
 			return runForAllAdaptors('logout', [], callback)
 		},

--- a/packages/resin-universal-ga/src/browser.js
+++ b/packages/resin-universal-ga/src/browser.js
@@ -35,7 +35,7 @@ module.exports = function (propertyId, site, debug) {
 					category, action, label,
 					options
 				)
-			})
+			}).timeout(1000);
 		}
 	}
 }

--- a/packages/resin-universal-ga/src/browser.js
+++ b/packages/resin-universal-ga/src/browser.js
@@ -4,6 +4,8 @@ var Promise = require('bluebird')
 var TRACKER_NAME = 'resinAnalytics'
 
 module.exports = function (propertyId, site, debug) {
+	loggedIn = false;
+
 	return {
 		login: function (userId) {
 			var options = {
@@ -13,16 +15,22 @@ module.exports = function (propertyId, site, debug) {
 				options.cookieDomain = 'none'
 			}
 			window.ga('create', propertyId, site, TRACKER_NAME, options)
+			loggedIn = true;
 		},
 		logout: function () {
+			if (!loggedIn) throw new Error("Can't record GA logout event before login");
+
 			return Promise.fromCallback(function (callback) {
 				window.ga(function() {
 					window.ga.remove(TRACKER_NAME)
+					loggedIn = false;
 					callback()
 				})
 			})
 		},
 		track: function (category, action, label) {
+			if (!loggedIn) throw new Error("Can't record GA events without a login first");
+
 			return Promise.fromCallback(function (callback) {
 				var options = {
 					hitCallback: callback

--- a/packages/resin-universal-ga/src/browser.js
+++ b/packages/resin-universal-ga/src/browser.js
@@ -18,7 +18,7 @@ module.exports = function (propertyId, site, debug) {
 			loggedIn = true;
 		},
 		logout: function () {
-			if (!loggedIn) throw new Error("Can't record GA logout event before login");
+			if (!loggedIn) throw new Error("GA logout called before login");
 
 			return Promise.fromCallback(function (callback) {
 				window.ga(function() {


### PR DESCRIPTION
This is part of fixing https://github.com/resin-io/resin-ui/issues/494.

Currently, we try to send GA events in `.track` here, even if we haven't yet called `.login`. In that case, they're guaranteed not to work, and never call the configured `hitCallback`. This PR stops us doing that, with a simple boolean flag set on login/logout, so that track requests immediately fail.

In addition, there's now a 1s timeout on GA requests, because this is what GA strongly recommends, as `hitCallback` might not get called for all sorts of other reasons: https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#handling_timeouts.

I've tested this quickly in the dashboard, and this plus https://github.com/resin-io/resin-ui/pull/495 does seems to solve the issue there nicely. This does leaves some error messages in the console. Medium-term we should probably try to avoid logging to GA entirely in situations like this, or reorganise our GA code so that it has a separate pathway to handle not being logged in, but this is sufficient to fix the immediate problem, and it'll need to be more resilient to these issues regardless.

I've put this in the changelog for `resin-event-log`, rather than `resin-universal-ga`, because that doesn't seem to have its own changelog. Not sure how we're managing this with Lerna.