### PR TITLE
Allow overriding the mixpanel api host

### DIFF
--- a/packages/resin-event-log/CHANGELOG.md
+++ b/packages/resin-event-log/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Accept a new `mixpanelHost` option to override the mixpanel API domain
+
 # 1.3.0
 
 * Mixpanel users will be created if they do not exist on `login`/`signup` in Node (this previously only happened in the browser).

--- a/packages/resin-event-log/README.md
+++ b/packages/resin-event-log/README.md
@@ -16,6 +16,7 @@ var EventLog = require('resin-event-log')
 var eventLogger = EventLog({
 	debug: true,
 	mixpanelToken: MIXPANEL_TOKEN,
+	mixpanelHost: 'api.mixpanel.com',
 	gaSite: 'resin.io',
 	gaId: GA_ID,
 	prefix: 'UI, CLI, etc.',
@@ -49,6 +50,7 @@ eventLoger.user.login()
 * `prefix` - subsystem name like UI or CLI, acts as events names prefix
 * `[debug = false]` — will print some warnings
 * `[mixpanelToken = null]` - if set events will be reported to mixpanel
+* `[mixpanelHost = null]` - if set will override the default mixpanel API host
 * `[gaSite = null]`, `[gaSite = null]` - if set events will be reported to GA
 
 ### Hooks:

--- a/packages/resin-event-log/src/adaptors/mixpanel.js
+++ b/packages/resin-event-log/src/adaptors/mixpanel.js
@@ -31,7 +31,11 @@ var getMixpanelUser = function(userData) {
 
 module.exports = function (options) {
 	var debug = options.debug,
-		token = options.mixpanelToken
+		token = options.mixpanelToken,
+		mixpanelOptions = options.mixpanelHost ? {
+			api_host: options.mixpanelHost,
+			decide_host: options.mixpanelHost
+		} : {}
 
 	if (!token) {
 		if (debug) {
@@ -40,7 +44,7 @@ module.exports = function (options) {
 		return null
 	}
 
-	var mixpanel = ResinMixpanelClient(token)
+	var mixpanel = ResinMixpanelClient(token, mixpanelOptions)
 
 	return {
 		login: function(user) {

--- a/packages/resin-mixpanel-client/CHANGELOG.md
+++ b/packages/resin-mixpanel-client/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Accept a mixpanel options object
+
 # 2.0.0
 
 * Mixpanel users will be created if they do not exist on `login`/`signup` in Node (this previously only happened in the browser).

--- a/packages/resin-mixpanel-client/README.md
+++ b/packages/resin-mixpanel-client/README.md
@@ -13,24 +13,26 @@ $ npm install resin-mixpanel-client
 ```javascript
 var MixpanelClient = require('resin-mixpanel-client')
 
+var client = MixpanelClient(token, options)
+
 if (eventType === 'signup') {
-	MixpanelClient.signup(userId)
+	client.signup(userId)
 }
 
 if (eventType === 'login') {
-	MixpanelClient.login(userId)
+	client.login(userId)
 }
 
-MixpanelClient.set(props)
-MixpanelClient.setOnce(props)
+client.set(props)
+client.setOnce(props)
 
-MixpanelClient.setUser(props)
-MixpanelClient.setUserOnce(props)
+client.setUser(props)
+client.setUserOnce(props)
 
-MixpanelClient.track(eventName, props)
+client.track(eventName, props)
 
 if (eventType is 'logout') {
-	MixpanelClient.logout()
+	client.logout()
 }
 ```
 

--- a/packages/resin-mixpanel-client/src/resin-mixpanel-client.js
+++ b/packages/resin-mixpanel-client/src/resin-mixpanel-client.js
@@ -1,9 +1,9 @@
 var Promise = require('bluebird')
 var mixpanelLib = require('resin-universal-mixpanel')
 
-module.exports = function(token) {
+module.exports = function(token, options) {
 
-	var mixpanel = mixpanelLib.init(token)
+	var mixpanel = mixpanelLib.init(token, options)
 	var isBrowser = typeof window !== 'undefined'
 
 	mixpanel.set_config({

--- a/packages/resin-universal-mixpanel/CHANGELOG.md
+++ b/packages/resin-universal-mixpanel/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Accept mixpanel options passed to .init()
+
 # 2.0.0
 
 * **Breaking!** Mixpanel is now returned synchronously in Node and the Browser, not wrapped in a promise.

--- a/packages/resin-universal-mixpanel/src/browser.js
+++ b/packages/resin-universal-mixpanel/src/browser.js
@@ -4,8 +4,8 @@ var TRACKER_NAME = 'resinAnalytics'
 
 // normalize the API to match the one of the node module
 module.exports = {
-	init: function(token) {
-		mixpanel.init(token, {}, TRACKER_NAME)
+	init: function(token, options) {
+		mixpanel.init(token, options, TRACKER_NAME)
 		return mixpanel[TRACKER_NAME]
 	}
 }

--- a/packages/resin-universal-mixpanel/src/node.js
+++ b/packages/resin-universal-mixpanel/src/node.js
@@ -2,8 +2,8 @@ var mixpanelLib = require('mixpanel')
 
 // normalize the API to match the one of the node module
 module.exports = {
-	init: function(token) {
-		var mixpanel = mixpanelLib.init(token)
+	init: function(token, options) {
+		var mixpanel = mixpanelLib.init(token, options)
 		return mixpanel
 	}
 }


### PR DESCRIPTION
The two low-level mixpanel libraries now allow arbitrary mixpanel options. At the `resin-event-log` level we accept one option (`mixpanelHost`) which we then use to configure the options passed down.

This connects to https://github.com/resin-io/hq/issues/731 - with this in place, we can configure the host used from the UI (to use the API instead).