### PR TITLE
add gosquared

### DIFF
--- a/packages/resin-event-log/package.json
+++ b/packages/resin-event-log/package.json
@@ -7,7 +7,8 @@
     "bluebird": "^3.4.7",
     "lodash": "^4.0.0",
     "resin-mixpanel-client": "^2.1.0",
-    "resin-universal-ga": "^1.1.0"
+    "resin-universal-ga": "^1.1.0",
+    "resin-universal-gosquared": "^0.1.0"
   },
   "devDependencies": {
     "base-64": "^0.1.0",

--- a/packages/resin-event-log/src/adaptors/gosquared.js
+++ b/packages/resin-event-log/src/adaptors/gosquared.js
@@ -1,0 +1,36 @@
+var ResinGsClient = require('resin-universal-gosquared')
+
+module.exports = function (options) {
+	var debug = options.debug,
+		gosquaredId = options.gosquaredId,
+		apiKey = options.gosquaredApiKey,
+		isBrowser = typeof window !== 'undefined'
+
+	if (!gosquaredId) {
+		if (debug) {
+			console.warn("`gosquaredId` is not set, gosquared tracking is disabled")
+		}
+		return null
+	}
+
+	if (!isBrowser && !apiKey) {
+		if (debug) {
+			console.warn("`gosquaredApiKey` is not set, gosquared tracking is disabled")
+		}
+		return null
+	}
+
+	var gsClient = ResinGsClient(gosquaredId, apiKey, debug)
+
+	return {
+		login: function(user) {
+			return gsClient.login(user.id)
+		},
+		logout: function() {
+			return gsClient.logout()
+		},
+		track: function (prefix, type, data) {
+			return gsClient.track(prefix, type, data)
+		}
+	}
+}

--- a/packages/resin-event-log/src/resin-event-log.js
+++ b/packages/resin-event-log/src/resin-event-log.js
@@ -11,7 +11,8 @@ var EVENTS = {
 	application: [ 'create', 'open', 'delete', 'osDownload' ],
 	environmentVariable: [ 'create', 'edit', 'delete' ],
 	device: [ 'open', 'rename', 'delete', 'terminalOpen', 'terminalClose' ],
-	deviceEnvironmentVariable: [ 'create', 'edit', 'delete' ]
+	deviceEnvironmentVariable: [ 'create', 'edit', 'delete' ],
+	page: [ 'visit' ]
 }
 
 var DEFAULT_HOOKS = {
@@ -23,7 +24,8 @@ var DEFAULT_HOOKS = {
 
 var ADAPTORS = [
 	require('./adaptors/ga'),
-	require('./adaptors/mixpanel')
+	require('./adaptors/mixpanel'),
+	require('./adaptors/gosquared')
 ]
 
 module.exports = function(options) {

--- a/packages/resin-universal-gosquared/CHANGELOG.md
+++ b/packages/resin-universal-gosquared/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.0
+
+* Add node and browser modules.

--- a/packages/resin-universal-gosquared/README.md
+++ b/packages/resin-universal-gosquared/README.md
@@ -1,0 +1,11 @@
+# Resin Universal gosquared Wrapper
+
+Loads the `gosquared` module in Node.js and (asynchronously) the client library from the CDN in the browser.
+
+Browser usage needs Webpack, Browserify or other bundler that tolerates the `browser` field in `package.json`.
+
+## Installing
+
+```sh
+$ npm install resin-universal-gosquared
+```

--- a/packages/resin-universal-gosquared/package.json
+++ b/packages/resin-universal-gosquared/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "resin-universal-gosquared",
+  "version": "0.1.0",
+  "description": "A CommonJS wrapper for both Node.js and browser (async) version of goSquared Analytics library",
+  "main": "src/node.js",
+  "browser": "src/browser.js",
+  "scripts": {},
+  "keywords": [],
+  "author": "Craig Mulligan <craig@resin.io>",
+  "license": "Apache-2.0",
+  "dependencies": {
+    "bluebird": "^3.4.7",
+    "gosquared": "3.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:resin-io-modules/resin-analytics.git"
+  },
+  "homepage": "https://github.com/resin-io-modules/resin-analytics"
+}

--- a/packages/resin-universal-gosquared/src/browser.js
+++ b/packages/resin-universal-gosquared/src/browser.js
@@ -1,0 +1,45 @@
+require('./gs-loader')
+
+var Promise = require('bluebird')
+var TRACKER_NAME = 'resinAnalytics'
+
+module.exports = function (gosquaredId, apiKey, debug) {
+	loggedIn = false
+	return {
+		login: function (userId) {
+			// automatically track pageviews in debug mode
+			window._gs(gosquaredId, TRACKER_NAME, debug)
+			window._gs(TRACKER_NAME + '.set', 'trackLocal', debug)
+
+			if (userId) {
+				window._gs(TRACKER_NAME + '.identify', {
+					id: userId
+				})
+			}
+			loggedIn = true
+		},
+		logout: function () {
+			if (!loggedIn) return Promise.reject(new Error("gosquared logout called before login"))
+
+			return Promise.fromCallback(function (callback) {
+				window._gs(function() {
+					window._gs(TRACKER_NAME + '.unidentify')
+					loggedIn = false
+					callback()
+				})
+			})
+		},
+		track: function (prefix, type, data) {
+			if (!loggedIn) return Promise.reject(new Error("Can't record gosquared events without a login first"))
+
+			return Promise.fromCallback(function (callback) {
+				if (type === 'Page Visit') {
+					window._gs(TRACKER_NAME + '.track', data.url || window.location.pathname)
+				} else {
+					window._gs(TRACKER_NAME + '.event', '[' + prefix + '] ' + type, data)
+				}
+				callback()
+			})
+		},
+	}
+}

--- a/packages/resin-universal-gosquared/src/gs-loader.js
+++ b/packages/resin-universal-gosquared/src/gs-loader.js
@@ -1,0 +1,10 @@
+(function(i,s,o,g,r,a,m){i['goSquaredObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(
+	window,
+	document,
+	'script',
+	'https://d1l6p2sc9645hc.cloudfront.net/tracker.js',
+	'_gs'
+);

--- a/packages/resin-universal-gosquared/src/node.js
+++ b/packages/resin-universal-gosquared/src/node.js
@@ -1,0 +1,38 @@
+var Promise = require('bluebird')
+var GoSquared = require('gosquared')
+
+module.exports = function(gosquaredId, apiKey, debug) {
+	var visitor = null
+	function createVisitor(userId) {
+		if (visitor) return visitor
+		var gosquared = new GoSquared({
+			api_key: apiKey,
+			site_token: gosquaredId
+		})
+		if (userId) {
+			visitor = gosquared.createPerson(userId);
+		} else {
+			visitor = gosquared
+		}
+	}
+	function destroyVisitor() {
+		visitor = null
+	}
+	return {
+		login: function(userId) {
+			createVisitor(userId)
+		},
+		logout: function() {
+			destroyVisitor()
+		},
+		track: function(prefix, type, data) {
+			// if called before `login` create an event without user attached.
+			createVisitor()
+			return Promise.fromCallback(function (callback) {
+				// node sdk doesn't support pageviews so no conditional here.
+				// https://www.gosquared.com/docs/api/tracking/pageview/node/
+				visitor.trackEvent('[' + prefix + '] ' + type, data, callback)
+			})
+		}
+	}
+}


### PR DESCRIPTION
Connects to #13

This adds gosquared for browser and node.js, it keeps the modules current handling of non authenticated uses as mentioned in #12 (will handle that in a seperate PR). 

Current issue is that I can't get the browser tests to pass for gosquared. I've tested it manually in a browser and it works but with karma the nock request is never fulfilled and I'm struggling to debug effectively.

The `nockRequest.isDone()` continues to return false, I'm confident the track method is being called. 

Any ideas? 

I saw something about xhr transport that's needed for the ga tests? Could it be related?

Change-type: minor