### PR TITLE
Only load ga if it isn't already loaded

### DIFF
--- a/packages/resin-universal-ga/src/browser.js
+++ b/packages/resin-universal-ga/src/browser.js
@@ -1,4 +1,6 @@
-require('./ga-loader')
+if (window.ga === undefined) {
+	require('./ga-loader')
+}
 
 var Promise = require('bluebird')
 var TRACKER_NAME = 'resinAnalytics'
@@ -23,7 +25,7 @@ module.exports = function (propertyId, site, debug) {
 		},
 		login: function (userId) {
 			this.boot()
-			ga(TRACKER_NAME + '.set', 'userId', userId)
+			window.ga(TRACKER_NAME + '.set', 'userId', userId)
 		},
 		logout: function () {
 			return Promise.fromCallback(function (callback) {


### PR DESCRIPTION
Connects to #26
In some cases (the etchersite) we are loading google analytics earlier
so we can do a/b tests before the js is parsed. In that case we don't
want to load the script again.

Change-Type: patch